### PR TITLE
fix: Incorrect link to collage generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A modern web app that creates a collage of GitHub profile pictures based on a li
 
 ## How to Use
 
-1. Visit the [GitHub Profile Collage Generator](https://yourusername.github.io/collage_js/)
+1. Visit the [GitHub Profile Collage Generator](https://link-.github.io/collage)
 2. Enter GitHub usernames, one per line
 3. Click "Generate Collage"
 4. Once the collage is created, click "Download Collage" to save it as a PNG


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the URL for the GitHub Profile Collage Generator.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18): Updated the URL for the GitHub Profile Collage Generator from `https://yourusername.github.io/collage_js/` to `https://link-.github.io/collage`.